### PR TITLE
Removed/qualified unused variable and parameters

### DIFF
--- a/src/Device/Driver/AR62xx.cpp
+++ b/src/Device/Driver/AR62xx.cpp
@@ -101,7 +101,8 @@ class AR62xxDevice final : public AbstractDevice {
   //! Port the radio is connected to (from KRT2.cpp)
   Port &port; 
   //! Expected message length just receiving (from KRT2.cpp)
-  size_t expected_msg_length{};
+  // (at least currently) unused for AR62xx driver
+  // size_t expected_msg_length{};
   //! Buffer for messages from radio (from KRT2.cpp)
   StaticFifoBuffer<uint8_t, 256u> rx_buf;
   //! Last response received from the radio (frome KRT2.cpp)
@@ -614,9 +615,11 @@ AR62xxDevice::PutStandbyFrequency(RadioFrequency frequency,
 /*
  * Assign the selected port on Object construction
  * same as in KRT2.cpp
+ * TB 28.12.22: added [[maybe_unused]] to "&config" parameter as otherwise a compile error will be thrown as this parameter is indeed
+ * currently unused
  */
 static Device *
-AR62xxCreateOnPort(const DeviceConfig &config, 
+AR62xxCreateOnPort([[maybe_unused]] const DeviceConfig &config, 
                                   Port &comPort)
 {
   Device *dev = new AR62xxDevice(comPort);


### PR DESCRIPTION
In line 104 expected_msg_length is declared but throughout the driver it is unused which prompts the compiler to throw an error. Commented this parameter as at a later stage it maybe used (dunno, really).

In line 619 (now 622) the "const DeviceConfig &config" parameter is declared (presumably because of the generic interface) but it isn't used. This prompts the compiler to throw an error. Added the "[[maybe_unused]]" directive to that parameter.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
